### PR TITLE
Handle alpha unit numbers

### DIFF
--- a/lib/us_street.rb
+++ b/lib/us_street.rb
@@ -36,7 +36,7 @@ class UsStreet
   def self.components; COMPONENTS; end
 
   def self.clean(str)
-    str.to_s.gsub(/([\.,:;]|\(.*?\))/, '').gsub(/.#\d+$/, '').gsub(/\s+/, ' ').strip.downcase.presence
+    str.to_s.gsub(/([\.,:;]|\(.*?\))/, '').gsub(/.#[a-zA-Z0-9]+$/, '').gsub(/\s+/, ' ').strip.downcase.presence
   end
 
   def self.clean_hash(hash)
@@ -82,8 +82,8 @@ class UsStreet
     sidx, eidx = 0, parts.length - 1
     unit_number = dir_suffix = dir_prefix = street_suffix = street_number = road_number = nil
 
-    # We could have a unit number last. Format '#\d+' but it's removed by the cleaners so match the original
-    if match = original_full_street.match(/#(\d+)$/)
+    # We could have a unit number last. Format '#[a-zA-Z0-9]+' but it's removed by the cleaners so match the original
+    if match = original_full_street.match(/#([a-zA-Z0-9]+)$/)
       unit_number = match[1]
     end
 
@@ -125,9 +125,9 @@ class UsStreet
     # Time to build up the output, prefer what was passed in
     # Note: We needed to decompose the street because the street may have had the components put into it
     # by some unsavoury operators :'(
-    overrides_unit = overrides[:unit].to_s.try(:match, /(\d+)/).try(:captures).try(:first)
+    overrides_unit = overrides[:unit].to_s.try(:match, /([a-zA-Z0-9]+)/).try(:captures).try(:first)
     out = {
-      unit: overrides_unit || unit_number,
+      unit: (overrides_unit || unit_number).try(:upcase),
       dir_prefix: direction_mapping(overrides[:dir_prefix]).presence || dir_prefix,
       street_name: overrides[:street_name].presence || parts[sidx..eidx].join(' '),
       street_suffix: road_mapping(overrides[:street_suffix]).presence || street_suffix,

--- a/lib/us_street/version.rb
+++ b/lib/us_street/version.rb
@@ -1,3 +1,3 @@
 class UsStreet
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/us_street_spec.rb
+++ b/spec/us_street_spec.rb
@@ -167,6 +167,20 @@ describe UsStreet do
       expect(us_street.display).to eq('123 123rd St #15')
     end
 
+    it 'handles alpha unit numbers' do
+      us_street = UsStreet.parse('123 123rd st #C')
+      expect(us_street.unit).to eq('C')
+      expect(us_street.full_street).to eq('123 123rd St')
+      expect(us_street.display).to eq('123 123rd St #C')
+    end
+
+    it 'handles alpha unit numbers' do
+      us_street = UsStreet.parse('123 123rd st', unit: 'C')
+      expect(us_street.unit).to eq('C')
+      expect(us_street.full_street).to eq('123 123rd St')
+      expect(us_street.display).to eq('123 123rd St #C')
+    end
+
     it 'handles 123rd st without ordinals or street number' do
       us_street = UsStreet.parse('123 st')
       expect(us_street.street_number).to eq(nil)


### PR DESCRIPTION
We have an issue where we cannot handle alpha unit numbers right now. This allows the unit to be a letter or char after a # 
