### PR TITLE
Handle street names with terms separated by dashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.byebug_history
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in us_street.gemspec
 gemspec
 
-gem 'rspec'
-gem 'pry'
+group :development, :test do
+  gem 'rspec'
+  gem 'pry'
+  gem 'byebug'
+end


### PR DESCRIPTION
@visnup we don't actually handle the hawaii case properly right now
see the example below- '47-310' is considered part of the street name, not the house number
added a xit case for when we get around to it...
